### PR TITLE
fix: Slash Commands deployment

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "isabelle",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "isabelle",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "discord.js": "^14.16.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
     "": {
       "name": "isabelle",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "AGPL-3.0-or-later",
       "dependencies": {
         "discord.js": "^14.16.3",
         "dotenv": "^16.4.5"
@@ -17,6 +17,7 @@
         "@types/eslint__js": "^8.42.3",
         "@typescript-eslint/eslint-plugin": "^8.8.1",
         "@typescript-eslint/parser": "^8.8.1",
+        "cross-env": "^7.0.3",
         "eslint": "^9.14.0",
         "husky": "^9.1.6",
         "lint-staged": "^15.2.10",
@@ -339,10 +340,11 @@
       }
     },
     "node_modules/@eslint/plugin-kit": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.0.tgz",
-      "integrity": "sha512-vH9PiIMMwvhCx31Af3HiGzsVNULDbyVkHXwlemn/B0TFj/00ho3y55efXrUZTfQipxoHC5u4xq6zblww1zm1Ig==",
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.2.3.tgz",
+      "integrity": "sha512-2b/g5hRmpbb1o4GnTZax9N9m0FXzz9OV42ZzI4rDDMDuHUqigAiQCEWChBWCY4ztAGVRjoWT19v0yMmc5/L5kA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "levn": "^0.4.1"
       },
@@ -1144,11 +1146,31 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
-    "node_modules/cross-spawn": {
+    "node_modules/cross-env": {
       "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
       "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "private": true,
   "name": "isabelle",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Isabelle est un BOT Discord à destination des élèves de TELECOM Nancy, et plus particulièrement aux étudiants de la promotion 2027 des FISA",
   "author": "MAXOUXAX",
   "packageManager": "npm@10.9.0",

--- a/package.json
+++ b/package.json
@@ -24,11 +24,11 @@
     "type": "git",
     "url": "https://github.com/MAXOUXAX/Isabelle.git"
   },
-  "main": "src/index.js",
+  "exports": "./src/index.js",
   "type": "module",
   "scripts": {
-    "dev": "tsx watch src/index.ts",
-    "start": "node dist/index.js",
+    "dev": "cross-env NODE_ENV=development tsx watch src/index.ts",
+    "start": "cross-env NODE_ENV=production node dist/index.js",
     "build": "tsup src/index.ts --minify --tsconfig tsconfig.json",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
@@ -37,7 +37,10 @@
     "prepare": "husky"
   },
   "lint-staged": {
-    "*.{js,ts}": ["eslint --fix", "prettier -w"]
+    "*.{js,ts}": [
+      "eslint --fix",
+      "prettier -w"
+    ]
   },
   "dependencies": {
     "discord.js": "^14.16.3",
@@ -48,6 +51,7 @@
     "@types/eslint__js": "^8.42.3",
     "@typescript-eslint/eslint-plugin": "^8.8.1",
     "@typescript-eslint/parser": "^8.8.1",
+    "cross-env": "^7.0.3",
     "eslint": "^9.14.0",
     "husky": "^9.1.6",
     "lint-staged": "^15.2.10",

--- a/src/index.ts
+++ b/src/index.ts
@@ -25,9 +25,6 @@ client.once(Events.ClientReady, () => {
     console.log('Registering modules...');
     registerModules();
 
-    console.log('Deploying global commands...');
-    await commandManager.deployCommandsGlobally();
-
     if (process.env.NODE_ENV === 'development') {
       console.log('[DEVELOPMENT] Isabelle is running in development mode.');
 
@@ -69,6 +66,19 @@ client.once(Events.ClientReady, () => {
             `[DEVELOPMENT] Commands deployed for the ${developmentGuild.name} server!`,
           );
         });
+    } else if (process.env.NODE_ENV === 'production') {
+      console.log('[PRODUCTION] Isabelle is running in production mode.');
+
+      console.log('[PRODUCTION] Deploying global commands...');
+      await commandManager.deployCommandsGlobally();
+      console.log(
+        '[PRODUCTION] Global commands deployed! If this is the first time you deploy commands, it may take up to an hour before they are available.',
+      );
+    } else {
+      console.error(
+        'No valid environment specified. Please set the NODE_ENV environment variable to either "development" or "production".',
+      );
+      return process.exit(1);
     }
 
     console.log('Isabelle is ready to serve! 🚀');

--- a/src/index.ts
+++ b/src/index.ts
@@ -135,3 +135,24 @@ function registerModules() {
     console.log(`[Modules] Module ${module.name} initialized.`);
   }
 }
+
+client.on('guildCreate', async (guild) => {
+  if (process.env.NODE_ENV === 'development') {
+    const { size } = client.guilds.cache;
+
+    if (size > 1) {
+      console.error(
+        '[DEVELOPMENT] Isabelle is already connected to a guild. To avoid any errors, the program will not deploy commands for the new guild.',
+      );
+      return;
+    }
+
+    console.log(
+      `[DEVELOPMENT] New guild joined: ${guild.name} (id: ${guild.id}). Deploying commands for this guild...`,
+    );
+    await commandManager.deployCommandsForGuild(guild.id);
+    console.log(
+      `[DEVELOPMENT] Commands deployed for the ${guild.name} server!`,
+    );
+  }
+});

--- a/src/manager/commands/command.interface.ts
+++ b/src/manager/commands/command.interface.ts
@@ -1,7 +1,11 @@
-import { CommandInteraction, SlashCommandBuilder } from 'discord.js';
+import {
+  CommandInteraction,
+  SlashCommandBuilder,
+  SlashCommandSubcommandsOnlyBuilder,
+} from 'discord.js';
 
 export interface IsabelleCommand {
-  commandData: SlashCommandBuilder;
+  commandData: SlashCommandBuilder | SlashCommandSubcommandsOnlyBuilder;
 
   executeCommand(interaction: CommandInteraction): void | Promise<void>;
 }

--- a/src/manager/commands/command.manager.ts
+++ b/src/manager/commands/command.manager.ts
@@ -1,7 +1,7 @@
 import { config } from '@/config.js';
 import { IsabelleCommand } from '@/manager/commands/command.interface.js';
 import { IsabelleModule } from '@/modules/bot-module.js';
-import { REST, Routes, SlashCommandBuilder } from 'discord.js';
+import { REST, Routes } from 'discord.js';
 
 export class CommandManager {
   private commands = new Map<IsabelleModule, IsabelleCommand[]>();
@@ -24,13 +24,19 @@ export class CommandManager {
     return undefined;
   }
 
+  getFlatCommandsArray() {
+    return Array.from(this.commands.values())
+      .flat()
+      .map((command) => command.commandData);
+  }
+
   async deployCommandsGlobally() {
     try {
-      console.log('Started refreshing global application (/) commands.');
+      console.log(
+        'Registering global application commands (/) via REST API...',
+      );
 
-      const commands = Array.from(this.commands.values())
-        .flat()
-        .map((command) => command.commandData);
+      const commands = this.getFlatCommandsArray();
 
       await this.rest.put(
         Routes.applicationCommands(config.DISCORD_CLIENT_ID),
@@ -39,18 +45,21 @@ export class CommandManager {
         },
       );
 
-      console.log('Successfully reloaded global application (/) commands.');
+      console.log(
+        'Successfully registered global application commands (/) via REST API.',
+      );
     } catch (error) {
       console.error(error);
     }
   }
 
-  async deployCommandsForGuild(
-    guildId: string,
-    commands: SlashCommandBuilder[],
-  ) {
+  async deployCommandsForGuild(guildId: string) {
     try {
-      console.log('Started refreshing application (/) commands.');
+      console.log(
+        `Started registering application commands  (/) for guild ${guildId}.`,
+      );
+
+      const commands = this.getFlatCommandsArray();
 
       await this.rest.put(
         Routes.applicationGuildCommands(config.DISCORD_CLIENT_ID, guildId),
@@ -59,7 +68,9 @@ export class CommandManager {
         },
       );
 
-      console.log('Successfully reloaded application (/) commands.');
+      console.log(
+        'Successfully registered application commands (/) for guild via REST API.',
+      );
     } catch (error) {
       console.error(error);
     }

--- a/src/manager/commands/command.manager.ts
+++ b/src/manager/commands/command.manager.ts
@@ -20,8 +20,6 @@ export class CommandManager {
         return command;
       }
     }
-
-    return undefined;
   }
 
   getFlatCommandsArray() {

--- a/src/manager/commands/command.manager.ts
+++ b/src/manager/commands/command.manager.ts
@@ -54,7 +54,7 @@ export class CommandManager {
   async deployCommandsForGuild(guildId: string) {
     try {
       console.log(
-        `Started registering application commands  (/) for guild ${guildId}.`,
+        `Started registering application commands (/) for guild ${guildId}.`,
       );
 
       const commands = this.getFlatCommandsArray();

--- a/src/modules/hot-potato/commands/hot-potato.command.ts
+++ b/src/modules/hot-potato/commands/hot-potato.command.ts
@@ -2,11 +2,14 @@ import { IsabelleCommand } from '@/manager/commands/command.interface.js';
 import { CommandInteraction, SlashCommandBuilder } from 'discord.js';
 
 export class HotPotatoCommand implements IsabelleCommand {
-  commandData: SlashCommandBuilder = new SlashCommandBuilder().setName(
-    'hot-potato',
-  );
+  commandData: SlashCommandBuilder = new SlashCommandBuilder()
+    .setName('hot-potato')
+    .setDescription('Gérer les paramètres relatifs à la patate chaude.');
 
   async executeCommand(interaction: CommandInteraction) {
-    await interaction.reply('Hot potato!');
+    await interaction.reply({
+      ephemeral: true,
+      content: 'Commande en cours de développement.',
+    });
   }
 }


### PR DESCRIPTION
Remplace la PR de @ThomasRbn #2 

Corrige un bug de déploiement des Slash Commands.
1. Les commandes n'étaient jamais déployées globalement, ce qui rendait leur utilisation impossible 
2. Dans un environnement de développement, les commandes n'étaient pas déployées pour le serveur de développement, ce qui pouvait forcer une attente de plusieurs minutes avant de pouvoir utiliser une commande nouvellement créée.
3. Une des commandes du BOT ne définissait pas de description, ce qui empêchait l'enregistrement des commandes auprès de l'API de Discord, puisque cette information est requise.

# Breaking Changes

Le bot Discord utilisé en développement doit être présent dans AU PLUS UN SEUL SERVEUR DISCORD, puisque les commandes seront déployées sur cet unique serveur. Cette contrainte pourra faire l'objet d'une modification dans le cas où inviter le bot sur plusieurs serveurs devient nécessaire pour le développement d'une fonctionnalité (s'assurer que les données ne sont pas partagées entre plusieurs serveurs, que la configuration utilisée pour un module est bien celle définie par le serveur, et pas un autre, etc)