### PR TITLE
chore(ai): add Cursor Context7 MCP

### DIFF
--- a/.cursor/mcp.json
+++ b/.cursor/mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "context7": {
+      "command": "npx",
+      "args": ["-y", "@upstash/context7-mcp"]
+    }
+  }
+}


### PR DESCRIPTION
This pull request introduces a new MCP server configuration by adding a `.cursor/mcp.json` file. This configuration specifies how to run the `context7` MCP server using `npx` with the `@upstash/context7-mcp` package.

Configuration changes:

* Added `.cursor/mcp.json` to define the `context7` MCP server, specifying the command and arguments needed to launch it with `npx` and the `@upstash/context7-mcp` package.