### PR TITLE
[Jules] 🛡️ Sentinel: [HIGH] Fix Mass Mention vulnerabilities in sutom and russian-roulette games

### DIFF
--- a/src/modules/russian-roulette/commands/russian-roulette-play.command.ts
+++ b/src/modules/russian-roulette/commands/russian-roulette-play.command.ts
@@ -44,7 +44,10 @@ export const executePlayCommand = async (
   // No one got hit this round.
   if (targetId == null) {
     increaseGamesSinceLastKill();
-    await interaction.reply(randomSafeMessage);
+    await interaction.reply({
+      content: randomSafeMessage,
+      allowedMentions: { users: [interaction.user.id] },
+    });
     return;
   }
 
@@ -59,15 +62,19 @@ export const executePlayCommand = async (
       );
 
       increaseGamesSinceLastKill();
-      await interaction.reply(randomSafeMessage);
+      await interaction.reply({
+        content: randomSafeMessage,
+        allowedMentions: { users: [interaction.user.id] },
+      });
       return;
     }
 
     if (!(member.moderatable || member.kickable)) {
       increaseGamesSinceLastKill();
-      await interaction.reply(
-        `Bang...? ${mentionId(targetId)} était trop puissant(e) pour être affecté(e). Le canon a fondu et tout le monde s'en sort vivant cette fois-ci !`,
-      );
+      await interaction.reply({
+        content: `Bang...? ${mentionId(targetId)} était trop puissant(e) pour être affecté(e). Le canon a fondu et tout le monde s'en sort vivant cette fois-ci !`,
+        allowedMentions: { users: [targetId, interaction.user.id] },
+      });
       logger.debug(
         `Target ${targetId} (${member.displayName}) is not moderatable - cannot timeout`,
       );
@@ -82,7 +89,10 @@ export const executePlayCommand = async (
         .replace('{shooter}', mentionId(interaction.user.id))
         .replace('{target}', mentionId(targetId));
 
-      await interaction.reply(preTargetMessage);
+      await interaction.reply({
+        content: preTargetMessage,
+        allowedMentions: { users: [targetId, interaction.user.id] },
+      });
     }
 
     // Get random timeout duration and message
@@ -108,9 +118,15 @@ export const executePlayCommand = async (
     const finalMessage = message.replace('{user}', mentionId(targetId));
     // If we already replied with the pre-target message (when target != shooter), followUp with the final timeout message
     if (targetId !== interaction.user.id) {
-      await interaction.followUp(finalMessage);
+      await interaction.followUp({
+        content: finalMessage,
+        allowedMentions: { users: [targetId, interaction.user.id] },
+      });
     } else {
-      await interaction.reply(finalMessage);
+      await interaction.reply({
+        content: finalMessage,
+        allowedMentions: { users: [targetId, interaction.user.id] },
+      });
     }
     logger.debug(
       { reason: 'Russian Roulette', duration: label },
@@ -124,9 +140,15 @@ export const executePlayCommand = async (
     increaseGamesSinceLastKill();
     const errorMessage = `Le pistolet s'enraye... Personne n'est sanctionné cette fois-ci (erreur : ${(e as Error).name}).`;
     if (interaction.replied) {
-      await interaction.followUp(errorMessage);
+      await interaction.followUp({
+        content: errorMessage,
+        allowedMentions: { users: [targetId, interaction.user.id] },
+      });
     } else {
-      await interaction.reply(errorMessage);
+      await interaction.reply({
+        content: errorMessage,
+        allowedMentions: { users: [targetId, interaction.user.id] },
+      });
     }
   }
 };

--- a/src/modules/russian-roulette/commands/russian-roulette-play.command.ts
+++ b/src/modules/russian-roulette/commands/russian-roulette-play.command.ts
@@ -46,7 +46,7 @@ export const executePlayCommand = async (
     increaseGamesSinceLastKill();
     await interaction.reply({
       content: randomSafeMessage,
-      allowedMentions: { users: [interaction.user.id] },
+      allowedMentions: { parse: [], users: [interaction.user.id] },
     });
     return;
   }
@@ -64,7 +64,7 @@ export const executePlayCommand = async (
       increaseGamesSinceLastKill();
       await interaction.reply({
         content: randomSafeMessage,
-        allowedMentions: { users: [interaction.user.id] },
+        allowedMentions: { parse: [], users: [interaction.user.id] },
       });
       return;
     }
@@ -73,7 +73,7 @@ export const executePlayCommand = async (
       increaseGamesSinceLastKill();
       await interaction.reply({
         content: `Bang...? ${mentionId(targetId)} était trop puissant(e) pour être affecté(e). Le canon a fondu et tout le monde s'en sort vivant cette fois-ci !`,
-        allowedMentions: { users: [targetId, interaction.user.id] },
+        allowedMentions: { parse: [], users: [targetId, interaction.user.id] },
       });
       logger.debug(
         `Target ${targetId} (${member.displayName}) is not moderatable - cannot timeout`,
@@ -91,7 +91,7 @@ export const executePlayCommand = async (
 
       await interaction.reply({
         content: preTargetMessage,
-        allowedMentions: { users: [targetId, interaction.user.id] },
+        allowedMentions: { parse: [], users: [targetId, interaction.user.id] },
       });
     }
 
@@ -120,12 +120,12 @@ export const executePlayCommand = async (
     if (targetId !== interaction.user.id) {
       await interaction.followUp({
         content: finalMessage,
-        allowedMentions: { users: [targetId, interaction.user.id] },
+        allowedMentions: { parse: [], users: [targetId, interaction.user.id] },
       });
     } else {
       await interaction.reply({
         content: finalMessage,
-        allowedMentions: { users: [targetId, interaction.user.id] },
+        allowedMentions: { parse: [], users: [targetId, interaction.user.id] },
       });
     }
     logger.debug(
@@ -138,16 +138,16 @@ export const executePlayCommand = async (
       `Failed to timeout user ${targetId} in Russian Roulette:`,
     );
     increaseGamesSinceLastKill();
-    const errorMessage = `Le pistolet s'enraye... Personne n'est sanctionné cette fois-ci (erreur : ${(e as Error).name}).`;
+    const errorMessage = `Le pistolet s'enraye... Personne n'est sanctionné cette fois-ci.`;
     if (interaction.replied) {
       await interaction.followUp({
         content: errorMessage,
-        allowedMentions: { users: [targetId, interaction.user.id] },
+        allowedMentions: { parse: [], users: [targetId, interaction.user.id] },
       });
     } else {
       await interaction.reply({
         content: errorMessage,
-        allowedMentions: { users: [targetId, interaction.user.id] },
+        allowedMentions: { parse: [], users: [targetId, interaction.user.id] },
       });
     }
   }

--- a/src/modules/sutom/commands/subcommands/sutom-guess.ts
+++ b/src/modules/sutom/commands/subcommands/sutom-guess.ts
@@ -38,7 +38,11 @@ export default async function guessWordSubcommand(
   }
 
   const sendEphemeral = (content: string) =>
-    interaction.reply({ content, flags: MessageFlags.Ephemeral });
+    interaction.reply({
+      content,
+      flags: MessageFlags.Ephemeral,
+      allowedMentions: { parse: [] },
+    });
 
   const userThreadId = sutomGameManager.getGameThreadId(user.id);
 
@@ -77,10 +81,18 @@ export default async function guessWordSubcommand(
 
   const responder: GuessResponder = {
     sendError: async (content: string) => {
-      await interaction.reply({ content, flags: MessageFlags.Ephemeral });
+      await interaction.reply({
+        content,
+        flags: MessageFlags.Ephemeral,
+        allowedMentions: { parse: [] },
+      });
     },
     sendBoard: async (embed: EmbedBuilder, attachment: AttachmentBuilder) => {
-      await interaction.reply({ embeds: [embed], files: [attachment] });
+      await interaction.reply({
+        embeds: [embed],
+        files: [attachment],
+        allowedMentions: { parse: [] },
+      });
     },
   };
 

--- a/src/modules/sutom/events/sutom-message.listener.ts
+++ b/src/modules/sutom/events/sutom-message.listener.ts
@@ -34,10 +34,14 @@ export async function sutomMessageListener(message: Message): Promise<void> {
 
   const responder: GuessResponder = {
     sendError: async (content: string) => {
-      await message.reply(content);
+      await message.reply({ content, allowedMentions: { parse: [] } });
     },
     sendBoard: async (embed: EmbedBuilder, attachment: AttachmentBuilder) => {
-      await message.reply({ embeds: [embed], files: [attachment] });
+      await message.reply({
+        embeds: [embed],
+        files: [attachment],
+        allowedMentions: { parse: [] },
+      });
     },
   };
 


### PR DESCRIPTION
## Duplicate Check
- Checked open PRs and recent merges: No similar security fix for mass mentions in `sutom` or `russian-roulette` exists.

🚨 Severity: HIGH
💡 Vulnerability: The `sutomMessageListener`, `guessWordSubcommand`, and `russian-roulette-play.command` utilities did not suppress or correctly restrict Discord mentions (`allowedMentions`). A malicious user could craft inputs (like a word guess containing `@everyone`) or exploit dynamic configuration messages to trigger mass notifications.
🎯 Impact: Attackers could abuse the bot to spam server members, bypassing typical user permission constraints.
🔧 Fix: Added `allowedMentions: { parse: [] }` in the SUTOM interactions and explicitly restricted mentions to `[targetId, interaction.user.id]` in the Russian Roulette game to strictly scope pings.
✅ Verification: Ran `npm run lint` and `npm run build` to verify correctness. Manual review confirmed that all updated endpoints now explicitly set `allowedMentions`.

---
*PR created automatically by Jules for task [2411832483758016746](https://jules.google.com/task/2411832483758016746) started by @MAXOUXAX*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Unified message reply patterns across Russian Roulette and Sutom game modules, standardizing the format and handling for ephemeral notifications, error messages, and game board updates to improve overall consistency.
  * Enhanced message event listener implementation to strengthen message delivery reliability and ensure consistent formatting throughout all user interactions, error handling, and game operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->