### PR TITLE
fix: remove aiSdk bundling configuration from tsdown config

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,13 +1,5 @@
 import { defineConfig } from 'tsdown';
 
-const aiSdk = [
-  /^ai$/,
-  /^@ai-sdk\//,
-  /^@vercel\/oidc$/,
-  /^@opentelemetry\/api$/,
-  /^eventsource-parser$/,
-];
-
 export default defineConfig({
   entry: ['src/index.ts'],
   minify: true,
@@ -20,7 +12,6 @@ export default defineConfig({
   dts: false,
   target: false,
   deps: {
-    alwaysBundle: aiSdk,
-    onlyBundle: aiSdk,
+    skipNodeModulesBundle: true,
   },
 });


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Simplified dependency bundling configuration by replacing specific package bundle rules with a unified skip option, streamlining the build setup without altering external functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->