### PR TITLE
[Jules] 🛡️ Sentinel: Fix mention spoofing in Russian Roulette error handling

### DIFF
--- a/src/modules/russian-roulette/commands/russian-roulette-play.command.ts
+++ b/src/modules/russian-roulette/commands/russian-roulette-play.command.ts
@@ -124,9 +124,15 @@ export const executePlayCommand = async (
     increaseGamesSinceLastKill();
     const errorMessage = `Le pistolet s'enraye... Personne n'est sanctionné cette fois-ci (erreur : ${(e as Error).name}).`;
     if (interaction.replied) {
-      await interaction.followUp(errorMessage);
+      await interaction.followUp({
+        content: errorMessage,
+        allowedMentions: { parse: [] },
+      });
     } else {
-      await interaction.reply(errorMessage);
+      await interaction.reply({
+        content: errorMessage,
+        allowedMentions: { parse: [] },
+      });
     }
   }
 };


### PR DESCRIPTION
### Duplicate Check
No duplicate or similar issues were found during the audit.

### Description
This pull request addresses a minor security issue in the Russian Roulette game command.
The `errorMessage` string interpolates the error name: `(e as Error).name`. If a user manages to trigger an error with a custom name containing a mention like `@everyone` or `@here`, it could spoof mass pings because `interaction.reply()` parses mentions by default.
To enforce failing securely and preventing unwanted pings, `allowedMentions: { parse: [] }` was added to both `interaction.reply` and `interaction.followUp` that send the error message.

### Fix
- Added `allowedMentions: { parse: [] }` to the specific `interaction.reply()` and `interaction.followUp()` calls used for `errorMessage` in `src/modules/russian-roulette/commands/russian-roulette-play.command.ts`.
- Preserved existing intentional mentions (`mentionId`) in other branches.

---
*PR created automatically by Jules for task [1152490630241145778](https://jules.google.com/task/1152490630241145778) started by @MAXOUXAX*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed error messages in Russian roulette game to prevent unintended mentions from being parsed and triggered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->