### PR TITLE
feat(birthdays): birthday tracking with daily announcements

### DIFF
--- a/drizzle/0015_tranquil_miss_america.sql
+++ b/drizzle/0015_tranquil_miss_america.sql
@@ -1,0 +1,13 @@
+CREATE TABLE `birthdays` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`guild_id` text NOT NULL,
+	`user_id` text NOT NULL,
+	`month` integer NOT NULL,
+	`day` integer NOT NULL,
+	`last_notified` integer,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch()) NOT NULL
+);
+--> statement-breakpoint
+CREATE INDEX `birthdays_month_day_idx` ON `birthdays` (`month`,`day`);--> statement-breakpoint
+CREATE UNIQUE INDEX `birthdays_guild_id_user_id_unique` ON `birthdays` (`guild_id`,`user_id`);

--- a/drizzle/0016_bouncy_whiplash.sql
+++ b/drizzle/0016_bouncy_whiplash.sql
@@ -1,0 +1,20 @@
+PRAGMA foreign_keys=OFF;--> statement-breakpoint
+CREATE TABLE `__new_birthdays` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`guild_id` text NOT NULL,
+	`user_id` text NOT NULL,
+	`month` integer NOT NULL,
+	`day` integer NOT NULL,
+	`last_notified` integer,
+	`created_at` integer DEFAULT (unixepoch()) NOT NULL,
+	`updated_at` integer DEFAULT (unixepoch()) NOT NULL,
+	CONSTRAINT "birthdays_month_check" CHECK("__new_birthdays"."month" between 1 and 12),
+	CONSTRAINT "birthdays_day_check" CHECK("__new_birthdays"."day" between 1 and 31)
+);
+--> statement-breakpoint
+INSERT INTO `__new_birthdays`("id", "guild_id", "user_id", "month", "day", "last_notified", "created_at", "updated_at") SELECT "id", "guild_id", "user_id", "month", "day", "last_notified", "created_at", "updated_at" FROM `birthdays`;--> statement-breakpoint
+DROP TABLE `birthdays`;--> statement-breakpoint
+ALTER TABLE `__new_birthdays` RENAME TO `birthdays`;--> statement-breakpoint
+PRAGMA foreign_keys=ON;--> statement-breakpoint
+CREATE INDEX `birthdays_month_day_idx` ON `birthdays` (`month`,`day`);--> statement-breakpoint
+CREATE UNIQUE INDEX `birthdays_guild_id_user_id_unique` ON `birthdays` (`guild_id`,`user_id`);

--- a/drizzle/meta/0015_snapshot.json
+++ b/drizzle/meta/0015_snapshot.json
@@ -1,0 +1,681 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "8860f711-166e-4ef6-b14c-9810d52b0100",
+  "prevId": "d51a4109-7fbf-4078-bc43-0e7a3ddd7d58",
+  "tables": {
+    "agenda_events": {
+      "name": "agenda_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "discord_event_id": {
+          "name": "discord_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "discord_thread_id": {
+          "name": "discord_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_start_time": {
+          "name": "event_start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_end_time": {
+          "name": "event_end_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_closed": {
+          "name": "thread_closed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "agenda_events_idx": {
+          "name": "agenda_events_idx",
+          "columns": [
+            "guild_id",
+            "event_start_time",
+            "event_end_time"
+          ],
+          "isUnique": false
+        },
+        "agenda_events_thread_close_idx": {
+          "name": "agenda_events_thread_close_idx",
+          "columns": [
+            "thread_closed",
+            "event_end_time"
+          ],
+          "isUnique": false
+        },
+        "agenda_events_guild_id_discord_event_id_unique": {
+          "name": "agenda_events_guild_id_discord_event_id_unique",
+          "columns": [
+            "guild_id",
+            "discord_event_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_legal_consent": {
+      "name": "audit_legal_consent",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consented": {
+          "name": "consented",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "audit_legal_consent_user_created_idx": {
+          "name": "audit_legal_consent_user_created_idx",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "audit_legal_consent_user_id_scope_created_at_unique": {
+          "name": "audit_legal_consent_user_id_scope_created_at_unique",
+          "columns": [
+            "user_id",
+            "scope",
+            "created_at"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "automatic_responses": {
+      "name": "automatic_responses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "probability": {
+          "name": "probability",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "automatic_responses_guild_id_idx": {
+          "name": "automatic_responses_guild_id_idx",
+          "columns": [
+            "guild_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "birthdays": {
+      "name": "birthdays",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "month": {
+          "name": "month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "day": {
+          "name": "day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_notified": {
+          "name": "last_notified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "birthdays_month_day_idx": {
+          "name": "birthdays_month_day_idx",
+          "columns": [
+            "month",
+            "day"
+          ],
+          "isUnique": false
+        },
+        "birthdays_guild_id_user_id_unique": {
+          "name": "birthdays_guild_id_user_id_unique",
+          "columns": [
+            "guild_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "guild_configs": {
+      "name": "guild_configs",
+      "columns": {
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reminders": {
+      "name": "reminders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "reminders_due_at_id_idx": {
+          "name": "reminders_due_at_id_idx",
+          "columns": [
+            "due_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "reminders_guild_user_due_at_id_idx": {
+          "name": "reminders_guild_user_due_at_id_idx",
+          "columns": [
+            "guild_id",
+            "user_id",
+            "due_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "roast_usage": {
+      "name": "roast_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "roast_usage_idx": {
+          "name": "roast_usage_idx",
+          "columns": [
+            "guild_id",
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "russian_roulette_stats": {
+      "name": "russian_roulette_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "shots": {
+          "name": "shots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "deaths": {
+          "name": "deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "timeout_minutes": {
+          "name": "timeout_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "russian_roulette_stats_guild_timeout_idx": {
+          "name": "russian_roulette_stats_guild_timeout_idx",
+          "columns": [
+            "guild_id",
+            "timeout_minutes",
+            "deaths",
+            "shots",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "russian_roulette_stats_guild_id_user_id_unique": {
+          "name": "russian_roulette_stats_guild_id_user_id_unique",
+          "columns": [
+            "guild_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0016_snapshot.json
+++ b/drizzle/meta/0016_snapshot.json
@@ -1,0 +1,690 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "1f883604-711e-40f6-b61d-be60872ff0c8",
+  "prevId": "8860f711-166e-4ef6-b14c-9810d52b0100",
+  "tables": {
+    "agenda_events": {
+      "name": "agenda_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "emoji": {
+          "name": "emoji",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "location": {
+          "name": "location",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "discord_event_id": {
+          "name": "discord_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "discord_thread_id": {
+          "name": "discord_thread_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_start_time": {
+          "name": "event_start_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "event_end_time": {
+          "name": "event_end_time",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "thread_closed": {
+          "name": "thread_closed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "agenda_events_idx": {
+          "name": "agenda_events_idx",
+          "columns": [
+            "guild_id",
+            "event_start_time",
+            "event_end_time"
+          ],
+          "isUnique": false
+        },
+        "agenda_events_thread_close_idx": {
+          "name": "agenda_events_thread_close_idx",
+          "columns": [
+            "thread_closed",
+            "event_end_time"
+          ],
+          "isUnique": false
+        },
+        "agenda_events_guild_id_discord_event_id_unique": {
+          "name": "agenda_events_guild_id_discord_event_id_unique",
+          "columns": [
+            "guild_id",
+            "discord_event_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "audit_legal_consent": {
+      "name": "audit_legal_consent",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consented": {
+          "name": "consented",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "audit_legal_consent_user_created_idx": {
+          "name": "audit_legal_consent_user_created_idx",
+          "columns": [
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        },
+        "audit_legal_consent_user_id_scope_created_at_unique": {
+          "name": "audit_legal_consent_user_id_scope_created_at_unique",
+          "columns": [
+            "user_id",
+            "scope",
+            "created_at"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "automatic_responses": {
+      "name": "automatic_responses",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "configuration": {
+          "name": "configuration",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "probability": {
+          "name": "probability",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 100
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "automatic_responses_guild_id_idx": {
+          "name": "automatic_responses_guild_id_idx",
+          "columns": [
+            "guild_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "birthdays": {
+      "name": "birthdays",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "month": {
+          "name": "month",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "day": {
+          "name": "day",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "last_notified": {
+          "name": "last_notified",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "birthdays_month_day_idx": {
+          "name": "birthdays_month_day_idx",
+          "columns": [
+            "month",
+            "day"
+          ],
+          "isUnique": false
+        },
+        "birthdays_guild_id_user_id_unique": {
+          "name": "birthdays_guild_id_user_id_unique",
+          "columns": [
+            "guild_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "birthdays_month_check": {
+          "name": "birthdays_month_check",
+          "value": "\"birthdays\".\"month\" between 1 and 12"
+        },
+        "birthdays_day_check": {
+          "name": "birthdays_day_check",
+          "value": "\"birthdays\".\"day\" between 1 and 31"
+        }
+      }
+    },
+    "guild_configs": {
+      "name": "guild_configs",
+      "columns": {
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "config": {
+          "name": "config",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "reminders": {
+      "name": "reminders",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "message": {
+          "name": "message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "due_at": {
+          "name": "due_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'queued'"
+        },
+        "attempts": {
+          "name": "attempts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "claimed_by": {
+          "name": "claimed_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "reminders_due_at_id_idx": {
+          "name": "reminders_due_at_id_idx",
+          "columns": [
+            "due_at",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "reminders_guild_user_due_at_id_idx": {
+          "name": "reminders_guild_user_due_at_id_idx",
+          "columns": [
+            "guild_id",
+            "user_id",
+            "due_at",
+            "id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "roast_usage": {
+      "name": "roast_usage",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "roast_usage_idx": {
+          "name": "roast_usage_idx",
+          "columns": [
+            "guild_id",
+            "user_id",
+            "created_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "russian_roulette_stats": {
+      "name": "russian_roulette_stats",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "guild_id": {
+          "name": "guild_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "plays": {
+          "name": "plays",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "shots": {
+          "name": "shots",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "deaths": {
+          "name": "deaths",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "timeout_minutes": {
+          "name": "timeout_minutes",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        }
+      },
+      "indexes": {
+        "russian_roulette_stats_guild_timeout_idx": {
+          "name": "russian_roulette_stats_guild_timeout_idx",
+          "columns": [
+            "guild_id",
+            "timeout_minutes",
+            "deaths",
+            "shots",
+            "id"
+          ],
+          "isUnique": false
+        },
+        "russian_roulette_stats_guild_id_user_id_unique": {
+          "name": "russian_roulette_stats_guild_id_user_id_unique",
+          "columns": [
+            "guild_id",
+            "user_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -106,6 +106,13 @@
       "when": 1774273130651,
       "tag": "0014_careless_black_knight",
       "breakpoints": true
+    },
+    {
+      "idx": 15,
+      "version": "6",
+      "when": 1782052935705,
+      "tag": "0015_tranquil_miss_america",
+      "breakpoints": true
     }
   ]
 }

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -113,6 +113,13 @@
       "when": 1782052935705,
       "tag": "0015_tranquil_miss_america",
       "breakpoints": true
+    },
+    {
+      "idx": 16,
+      "version": "6",
+      "when": 1782058059915,
+      "tag": "0016_bouncy_whiplash",
+      "breakpoints": true
     }
   ]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "AGPL-3.0-or-later",
       "dependencies": {
         "@ai-sdk/google": "^3.0.71",
+        "@discordjs/builders": "^1.13.0",
         "@libsql/client": "^0.17.3",
         "@napi-rs/canvas": "^1.0.0",
         "@resvg/resvg-js": "^2.6.2",
@@ -428,29 +429,6 @@
       "integrity": "sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==",
       "dev": true,
       "license": "Apache-2.0"
-    },
-    "node_modules/@emnapi/core": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@emnapi/wasi-threads": "1.2.1",
-        "tslib": "^2.4.0"
-      }
-    },
-    "node_modules/@emnapi/runtime": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "tslib": "^2.4.0"
-      }
     },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
@@ -1581,6 +1559,7 @@
       "resolved": "https://registry.npmjs.org/@libsql/client/-/client-0.17.3.tgz",
       "integrity": "sha512-HXk9wiAoJbKFbyBH4O+aEhN6ir5ERXuXvwE5OD2eR4/5RUa3Pw/8L9zrnVdU+iNJitRvisPWaIwmhkO3bH7giA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@libsql/core": "^0.17.3",
         "@libsql/hrana-client": "^0.10.0",
@@ -1851,9 +1830,6 @@
       "cpu": [
         "arm64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1873,9 +1849,6 @@
       "integrity": "sha512-LTUl9jS8WsLSUGaxQZKQkxfluOJRpgvBuxxdM4pYcjib+di8AU4OzQc6+L6SzGMLcKc9H0RAjojRatBhTMqYdg==",
       "cpu": [
         "arm64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1897,9 +1870,6 @@
       "cpu": [
         "riscv64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1920,9 +1890,6 @@
       "cpu": [
         "x64"
       ],
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1942,9 +1909,6 @@
       "integrity": "sha512-jnvr8NrLHiZ3NCiOKWqDbkI4Ah+QDrqtZ+sddPZBltEb1mQ2coSvCSJYfict+oAwcm0c970oTmVySpjKP/lnaA==",
       "cpu": [
         "x64"
-      ],
-      "libc": [
-        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2040,6 +2004,7 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -3150,6 +3115,7 @@
       "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -3373,6 +3339,7 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4448,6 +4415,7 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -5273,6 +5241,7 @@
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -7307,6 +7276,7 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -9780,6 +9750,7 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11068,6 +11039,7 @@
       "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -12189,6 +12161,7 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12437,9 +12410,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12457,9 +12427,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12477,9 +12444,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12497,9 +12461,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12517,9 +12478,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12537,9 +12495,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12671,6 +12626,7 @@
       "integrity": "sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.129.0",
         "@rolldown/pluginutils": "1.0.0"
@@ -13373,6 +13329,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13918,6 +13875,7 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -430,6 +430,29 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/@emnapi/core": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.1",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@emnapi/wasi-threads": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
@@ -1559,7 +1582,6 @@
       "resolved": "https://registry.npmjs.org/@libsql/client/-/client-0.17.3.tgz",
       "integrity": "sha512-HXk9wiAoJbKFbyBH4O+aEhN6ir5ERXuXvwE5OD2eR4/5RUa3Pw/8L9zrnVdU+iNJitRvisPWaIwmhkO3bH7giA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@libsql/core": "^0.17.3",
         "@libsql/hrana-client": "^0.10.0",
@@ -1830,6 +1852,9 @@
       "cpu": [
         "arm64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1849,6 +1874,9 @@
       "integrity": "sha512-LTUl9jS8WsLSUGaxQZKQkxfluOJRpgvBuxxdM4pYcjib+di8AU4OzQc6+L6SzGMLcKc9H0RAjojRatBhTMqYdg==",
       "cpu": [
         "arm64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -1870,6 +1898,9 @@
       "cpu": [
         "riscv64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1890,6 +1921,9 @@
       "cpu": [
         "x64"
       ],
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1909,6 +1943,9 @@
       "integrity": "sha512-jnvr8NrLHiZ3NCiOKWqDbkI4Ah+QDrqtZ+sddPZBltEb1mQ2coSvCSJYfict+oAwcm0c970oTmVySpjKP/lnaA==",
       "cpu": [
         "x64"
+      ],
+      "libc": [
+        "musl"
       ],
       "license": "MIT",
       "optional": true,
@@ -2004,7 +2041,6 @@
       "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@octokit/auth-token": "^6.0.0",
         "@octokit/graphql": "^9.0.3",
@@ -3115,7 +3151,6 @@
       "integrity": "sha512-plR3pp6D+SSUn1HM7xvSkx12/DhoHInI2YF35KAcVFNZvlC0gtrWqx7Qq1oH2Ssgi0vlFRCTbP+DZc7B9+TtsQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.59.2",
         "@typescript-eslint/types": "8.59.2",
@@ -3339,7 +3374,6 @@
       "integrity": "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -4415,7 +4449,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -5241,7 +5274,6 @@
       "integrity": "sha512-XbEXaRva5cF0ZQB8w6MluHA0kZZfV2DuCMJ3ozyEOHLwDpZX2Lmm/7Pp0xdJmI0GL1W05VH5VwIFHEm1Vcw2gw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.2",
@@ -7276,7 +7308,6 @@
       "integrity": "sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "marked": "bin/marked.js"
       },
@@ -9750,7 +9781,6 @@
       "dev": true,
       "inBundle": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11039,7 +11069,6 @@
       "integrity": "sha512-WRgl5GcypwramYX4HV+eQGzUbD7UUbljVmS+5G1uMwX/wLgYuJAxGeerXJDMO2xshng4+FXqCgyB5QfClV6WjA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@semantic-release/commit-analyzer": "^13.0.1",
         "@semantic-release/error": "^4.0.0",
@@ -12161,7 +12190,6 @@
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -12410,6 +12438,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12427,6 +12458,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12444,6 +12478,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12461,6 +12498,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12478,6 +12518,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12495,6 +12538,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -12626,7 +12672,6 @@
       "integrity": "sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/types": "=0.129.0",
         "@rolldown/pluginutils": "1.0.0"
@@ -13329,7 +13374,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -13875,7 +13919,6 @@
       "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
       "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
   },
   "dependencies": {
     "@ai-sdk/google": "^3.0.71",
+    "@discordjs/builders": "^1.13.0",
     "@libsql/client": "^0.17.3",
     "@napi-rs/canvas": "^1.0.0",
     "@resvg/resvg-js": "^2.6.2",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,6 +1,13 @@
 import { GuildConfig } from '@/manager/config.manager.js';
 import { sql } from 'drizzle-orm';
-import { index, int, sqliteTable, text, unique } from 'drizzle-orm/sqlite-core';
+import {
+  check,
+  index,
+  int,
+  sqliteTable,
+  text,
+  unique,
+} from 'drizzle-orm/sqlite-core';
 
 const base = () => {
   return {
@@ -156,5 +163,7 @@ export const birthdays = sqliteTable(
   (t) => [
     unique().on(t.guildId, t.userId),
     index('birthdays_month_day_idx').on(t.month, t.day),
+    check('birthdays_month_check', sql`${t.month} between 1 and 12`),
+    check('birthdays_day_check', sql`${t.day} between 1 and 31`),
   ],
 );

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -141,3 +141,20 @@ export const reminders = sqliteTable(
     ),
   ],
 );
+
+export const birthdays = sqliteTable(
+  'birthdays',
+  {
+    id: int('id').primaryKey({ autoIncrement: true }),
+    guildId: text('guild_id').notNull(),
+    userId: text('user_id').notNull(),
+    month: int('month').notNull(),
+    day: int('day').notNull(),
+    lastNotified: int('last_notified', { mode: 'timestamp' }),
+    ...base(),
+  },
+  (t) => [
+    unique().on(t.guildId, t.userId),
+    index('birthdays_month_day_idx').on(t.month, t.day),
+  ],
+);

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,7 @@
 import { commandManager } from '@/manager/commands/command.manager.js';
 import { AgendaModule } from '@/modules/agenda/agenda.module.js';
 import { AutomaticResponsesModule } from '@/modules/automatic-responses/automatic-responses.module.js';
+import { BirthdayModule } from '@/modules/birthdays/birthday.module.js';
 import { CoreModule } from '@/modules/core/core.module.js';
 import { legalManager } from '@/modules/legal/legal.manager.js';
 import { LegalModule } from '@/modules/legal/legal.module.js';
@@ -48,6 +49,7 @@ const MODULES: IsabelleModule[] = [
   new Schedule(),
   new RoastModule(),
   new RemindersModule(),
+  new BirthdayModule(),
 ];
 
 moduleManager.registerModules(MODULES);

--- a/src/manager/commands/command.manager.ts
+++ b/src/manager/commands/command.manager.ts
@@ -31,10 +31,7 @@ const collectAutocompleteOptions = (
       option.type === ApplicationCommandOptionType.SubcommandGroup
     ) {
       if ('options' in option) {
-        collectAutocompleteOptions(
-          option.options as RESTPostAPIChatInputApplicationCommandsJSONBody['options'],
-          names,
-        );
+        collectAutocompleteOptions(option.options, names);
       }
       continue;
     }
@@ -67,8 +64,7 @@ export class CommandManager {
    */
   async registerCommandsFromModule(module: IsabelleModule) {
     for (const command of module.commands) {
-      const commandJson =
-        command.commandData.toJSON() as unknown as RESTPostAPIChatInputApplicationCommandsJSONBody;
+      const commandJson = command.commandData.toJSON();
       const autocompleteOptions = getAutocompleteOptionNames(commandJson);
 
       if (autocompleteOptions.length > 0 && !isAutocompleteCommand(command)) {

--- a/src/manager/config.manager.ts
+++ b/src/manager/config.manager.ts
@@ -63,6 +63,7 @@ export interface GuildConfig {
   HOT_POTATO_TIMEOUT_DURATION?: number;
   AGENDA_FORUM_CHANNEL_ID?: string;
   AGENDA_ROLE_TO_MENTION?: string;
+  BIRTHDAY_CHANNEL_ID?: string;
 }
 
 export const configManager = new ConfigManager();

--- a/src/modules/birthdays/birthday.announcer.ts
+++ b/src/modules/birthdays/birthday.announcer.ts
@@ -1,0 +1,144 @@
+import { client } from '@/index.js';
+import { configManager } from '@/manager/config.manager.js';
+import { birthdayRepository } from '@/modules/birthdays/birthday.repository.js';
+import { isSameLocalDay } from '@/modules/birthdays/birthday.utils.js';
+import { createLogger } from '@/utils/logger.js';
+import { ContainerBuilder, TextDisplayBuilder } from '@discordjs/builders';
+import { MessageFlags } from 'discord.js';
+
+const logger = createLogger('birthday-announcer');
+
+/** Accent color of the announcement container (warm birthday gold). */
+const ANNOUNCEMENT_ACCENT_COLOR = 0xf2a900;
+
+/** Joins mentions as a natural French list: "@a, @b et @c". */
+function joinMentions(userIds: string[]): string {
+  const mentions = userIds.map((id) => `<@${id}>`);
+
+  if (mentions.length <= 1) {
+    return mentions.join('');
+  }
+
+  return `${mentions.slice(0, -1).join(', ')} et ${mentions[mentions.length - 1]}`;
+}
+
+function buildAnnouncement(userIds: string[]): string {
+  return `Aujourd'hui, on fête l'anniversaire de ${joinMentions(userIds)} ! Alors, joyeux anniversaire ! 🎂`;
+}
+
+/**
+ * Sends a birthday announcement for the given users to a guild's configured
+ * channel. Returns `true` if the message was sent, `false` if it was skipped
+ * (no channel configured or channel not sendable). Throws on send failure.
+ */
+async function sendAnnouncement(
+  guildId: string,
+  userIds: string[],
+): Promise<boolean> {
+  const channelId = configManager.getGuild(guildId).BIRTHDAY_CHANNEL_ID;
+
+  if (!channelId) {
+    logger.warn(
+      { guildId },
+      'Birthday announcement requested but no channel configured; skipping',
+    );
+    return false;
+  }
+
+  const channel = await client.channels.fetch(channelId);
+
+  if (!channel?.isSendable()) {
+    logger.warn(
+      { guildId, channelId },
+      'Configured birthday channel is not sendable; skipping',
+    );
+    return false;
+  }
+
+  const container = new ContainerBuilder()
+    .setAccentColor(ANNOUNCEMENT_ACCENT_COLOR)
+    .addTextDisplayComponents(
+      new TextDisplayBuilder().setContent(buildAnnouncement(userIds)),
+    );
+
+  await channel.send({
+    components: [container],
+    flags: MessageFlags.IsComponentsV2,
+    allowedMentions: { users: userIds, roles: [], parse: [] },
+  });
+
+  return true;
+}
+
+/**
+ * Sends a one-off preview announcement to the guild's configured channel,
+ * mentioning the given user. Used to verify the channel and message rendering
+ * without waiting for a real birthday. Does not touch the database.
+ *
+ * Returns `false` when no channel is configured or it isn't sendable.
+ */
+export function sendBirthdayPreview(
+  guildId: string,
+  userId: string,
+): Promise<boolean> {
+  return sendAnnouncement(guildId, [userId]);
+}
+
+/**
+ * Announces today's birthdays in each guild's configured channel.
+ *
+ * Idempotent: a birthday is only announced once per day thanks to the
+ * `lastNotified` marker, so it is safe to run on startup and on a schedule.
+ * Only birthdays falling on `now`'s calendar day are considered, so missed
+ * birthdays from previous days (e.g. while the bot was offline) are never
+ * back-announced.
+ */
+export async function announceBirthdays(now: Date = new Date()): Promise<void> {
+  const month = now.getMonth() + 1;
+  const day = now.getDate();
+
+  const todaysBirthdays = await birthdayRepository.getBirthdaysForDay(
+    month,
+    day,
+  );
+
+  const pending = todaysBirthdays.filter(
+    (birthday) => !isSameLocalDay(birthday.lastNotified, now),
+  );
+
+  if (pending.length === 0) {
+    return;
+  }
+
+  const byGuild = new Map<string, typeof pending>();
+  for (const birthday of pending) {
+    const existing = byGuild.get(birthday.guildId) ?? [];
+    existing.push(birthday);
+    byGuild.set(birthday.guildId, existing);
+  }
+
+  const notifiedIds: number[] = [];
+
+  for (const [guildId, entries] of byGuild) {
+    const userIds = entries.map((entry) => entry.userId);
+
+    try {
+      const sent = await sendAnnouncement(guildId, userIds);
+
+      if (sent) {
+        notifiedIds.push(...entries.map((entry) => entry.id));
+      }
+    } catch (error) {
+      logger.error({ error, guildId }, 'Failed to send birthday announcement');
+    }
+  }
+
+  try {
+    await birthdayRepository.markBirthdaysNotified(notifiedIds, now);
+  } catch (error) {
+    logger.error(
+      { error, count: notifiedIds.length },
+      'Failed to mark birthdays as notified',
+    );
+  }
+}

--- a/src/modules/birthdays/birthday.module.ts
+++ b/src/modules/birthdays/birthday.module.ts
@@ -20,9 +20,13 @@ export class BirthdayModule extends IsabelleModule {
   init(): void {
     this.registerCommand(new BirthdayCommand());
 
-    // Catch up on startup in case the bot was offline at the scheduled time.
-    // The check is idempotent, so this won't double-announce.
-    void this.runDailyCheck();
+    // Catch up only if today's scheduled time has already passed (e.g. the bot
+    // was offline at 07:45). Before that time, the scheduled timer fires today,
+    // so an immediate run would only announce prematurely. The check is
+    // idempotent, so this never double-announces.
+    if (new Date() >= this.scheduledTimeFor(new Date())) {
+      void this.runDailyCheck();
+    }
     this.scheduleNextCheck();
   }
 
@@ -33,10 +37,16 @@ export class BirthdayModule extends IsabelleModule {
     }
   }
 
+  /** Today's announcement time (local) for the calendar day of `reference`. */
+  private scheduledTimeFor(reference: Date): Date {
+    const scheduled = new Date(reference);
+    scheduled.setHours(ANNOUNCEMENT_HOUR, ANNOUNCEMENT_MINUTE, 0, 0);
+    return scheduled;
+  }
+
   private scheduleNextCheck(): void {
     const now = new Date();
-    const next = new Date(now);
-    next.setHours(ANNOUNCEMENT_HOUR, ANNOUNCEMENT_MINUTE, 0, 0);
+    const next = this.scheduledTimeFor(now);
 
     if (next <= now) {
       next.setDate(next.getDate() + 1);

--- a/src/modules/birthdays/birthday.module.ts
+++ b/src/modules/birthdays/birthday.module.ts
@@ -1,0 +1,58 @@
+import { announceBirthdays } from '@/modules/birthdays/birthday.announcer.js';
+import { BirthdayCommand } from '@/modules/birthdays/commands/birthday.command.js';
+import { IsabelleModule, ModuleContributor } from '@/modules/bot-module.js';
+import { createLogger } from '@/utils/logger.js';
+
+const logger = createLogger('module:birthdays');
+
+/** Time of day (local time) at which birthdays are announced. */
+const ANNOUNCEMENT_HOUR = 7;
+const ANNOUNCEMENT_MINUTE = 45;
+
+export class BirthdayModule extends IsabelleModule {
+  name = 'Birthdays';
+  contributors: ModuleContributor[] = [
+    { displayName: 'Maxence', githubUsername: 'MAXOUXAX' },
+  ];
+
+  private dailyTimeout: ReturnType<typeof setTimeout> | null = null;
+
+  init(): void {
+    this.registerCommand(new BirthdayCommand());
+
+    // Catch up on startup in case the bot was offline at the scheduled time.
+    // The check is idempotent, so this won't double-announce.
+    void this.runDailyCheck();
+    this.scheduleNextCheck();
+  }
+
+  destroy(): void {
+    if (this.dailyTimeout) {
+      clearTimeout(this.dailyTimeout);
+      this.dailyTimeout = null;
+    }
+  }
+
+  private scheduleNextCheck(): void {
+    const now = new Date();
+    const next = new Date(now);
+    next.setHours(ANNOUNCEMENT_HOUR, ANNOUNCEMENT_MINUTE, 0, 0);
+
+    if (next <= now) {
+      next.setDate(next.getDate() + 1);
+    }
+
+    this.dailyTimeout = setTimeout(() => {
+      void this.runDailyCheck();
+      this.scheduleNextCheck();
+    }, next.getTime() - now.getTime());
+  }
+
+  private async runDailyCheck(): Promise<void> {
+    try {
+      await announceBirthdays();
+    } catch (error) {
+      logger.error({ error }, 'Birthday announcement check failed');
+    }
+  }
+}

--- a/src/modules/birthdays/birthday.module.ts
+++ b/src/modules/birthdays/birthday.module.ts
@@ -16,8 +16,11 @@ export class BirthdayModule extends IsabelleModule {
   ];
 
   private dailyTimeout: ReturnType<typeof setTimeout> | null = null;
+  private isDestroyed = false;
+  private isCheckRunning = false;
 
   init(): void {
+    this.isDestroyed = false;
     this.registerCommand(new BirthdayCommand());
 
     // Catch up only if today's scheduled time has already passed (e.g. the bot
@@ -31,6 +34,7 @@ export class BirthdayModule extends IsabelleModule {
   }
 
   destroy(): void {
+    this.isDestroyed = true;
     if (this.dailyTimeout) {
       clearTimeout(this.dailyTimeout);
       this.dailyTimeout = null;
@@ -45,6 +49,10 @@ export class BirthdayModule extends IsabelleModule {
   }
 
   private scheduleNextCheck(): void {
+    if (this.isDestroyed) {
+      return;
+    }
+
     const now = new Date();
     const next = this.scheduledTimeFor(now);
 
@@ -53,16 +61,27 @@ export class BirthdayModule extends IsabelleModule {
     }
 
     this.dailyTimeout = setTimeout(() => {
-      void this.runDailyCheck();
-      this.scheduleNextCheck();
+      void (async () => {
+        await this.runDailyCheck();
+        this.scheduleNextCheck();
+      })();
     }, next.getTime() - now.getTime());
   }
 
   private async runDailyCheck(): Promise<void> {
+    // Guard against overlapping runs (startup catch-up + timer) so a birthday is
+    // never announced twice before `lastNotified` is persisted.
+    if (this.isDestroyed || this.isCheckRunning) {
+      return;
+    }
+
+    this.isCheckRunning = true;
     try {
       await announceBirthdays();
     } catch (error) {
       logger.error({ error }, 'Birthday announcement check failed');
+    } finally {
+      this.isCheckRunning = false;
     }
   }
 }

--- a/src/modules/birthdays/birthday.permissions.ts
+++ b/src/modules/birthdays/birthday.permissions.ts
@@ -1,0 +1,13 @@
+import { ChatInputCommandInteraction, PermissionFlagsBits } from 'discord.js';
+
+/**
+ * Permission required to manage other members' birthdays (setting them for
+ * someone else, removing them) and to configure the module.
+ */
+export const BIRTHDAY_ADMIN_PERMISSION = PermissionFlagsBits.ManageGuild;
+
+export function isBirthdayAdmin(
+  interaction: ChatInputCommandInteraction,
+): boolean {
+  return interaction.memberPermissions?.has(BIRTHDAY_ADMIN_PERMISSION) ?? false;
+}

--- a/src/modules/birthdays/birthday.repository.ts
+++ b/src/modules/birthdays/birthday.repository.ts
@@ -1,0 +1,55 @@
+import { db } from '@/db/index.js';
+import { birthdays } from '@/db/schema.js';
+import { and, eq, inArray } from 'drizzle-orm';
+
+class BirthdayRepository {
+  setBirthday(guildId: string, userId: string, month: number, day: number) {
+    return db
+      .insert(birthdays)
+      .values({
+        guildId,
+        userId,
+        month,
+        day,
+      })
+      .onConflictDoUpdate({
+        target: [birthdays.guildId, birthdays.userId],
+        // Reset the notification marker so a corrected date still gets announced.
+        set: { month, day, lastNotified: null },
+      });
+  }
+
+  removeBirthday(guildId: string, userId: string) {
+    return db
+      .delete(birthdays)
+      .where(and(eq(birthdays.guildId, guildId), eq(birthdays.userId, userId)));
+  }
+
+  listBirthdays(guildId: string) {
+    return db.select().from(birthdays).where(eq(birthdays.guildId, guildId));
+  }
+
+  /**
+   * Returns every birthday matching a given day, across all guilds.
+   * Used by the daily announcement job.
+   */
+  getBirthdaysForDay(month: number, day: number) {
+    return db
+      .select()
+      .from(birthdays)
+      .where(and(eq(birthdays.month, month), eq(birthdays.day, day)));
+  }
+
+  markBirthdaysNotified(ids: number[], notifiedAt: Date) {
+    if (ids.length === 0) {
+      return Promise.resolve();
+    }
+
+    return db
+      .update(birthdays)
+      .set({ lastNotified: notifiedAt })
+      .where(inArray(birthdays.id, ids));
+  }
+}
+
+export const birthdayRepository = new BirthdayRepository();

--- a/src/modules/birthdays/birthday.utils.ts
+++ b/src/modules/birthdays/birthday.utils.ts
@@ -1,0 +1,99 @@
+import { time, TimestampStyles } from 'discord.js';
+
+/** Maximum day for each 1-indexed month. February allows 29 to accept leap-year birthdays. */
+const MAX_DAY_PER_MONTH = [31, 29, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31];
+export function isValidMonthDay(month: number, day: number): boolean {
+  if (month < 1 || month > 12) {
+    return false;
+  }
+
+  return day >= 1 && day <= MAX_DAY_PER_MONTH[month - 1];
+}
+
+export function formatDayMonth(day: number, month: number): string {
+  return `${day.toString().padStart(2, '0')}/${month.toString().padStart(2, '0')}`;
+}
+
+const longDayMonthFormatter = new Intl.DateTimeFormat('fr-FR', {
+  day: 'numeric',
+  month: 'long',
+});
+
+/** Formats a day/month as full French text, e.g. "26 mars". */
+export function formatLongDayMonth(day: number, month: number): string {
+  // 2000 is a leap year, so 29/02 formats correctly.
+  return longDayMonthFormatter.format(new Date(2000, month - 1, day));
+}
+
+/**
+ * Returns the next calendar date (local midnight) on which the given day/month
+ * occurs, relative to `from`. When the birthday is today, returns today.
+ */
+export function nextBirthdayDate(month: number, day: number, from: Date): Date {
+  const reference = new Date(
+    from.getFullYear(),
+    from.getMonth(),
+    from.getDate(),
+  );
+
+  let next = new Date(from.getFullYear(), month - 1, day);
+  if (next < reference) {
+    next = new Date(from.getFullYear() + 1, month - 1, day);
+  }
+
+  return next;
+}
+
+/**
+ * Number of days from `from` until the next occurrence of the given day/month,
+ * wrapping around the end of the year. Returns 0 when the birthday is today.
+ */
+export function daysUntilBirthday(
+  month: number,
+  day: number,
+  from: Date,
+): number {
+  const reference = new Date(
+    from.getFullYear(),
+    from.getMonth(),
+    from.getDate(),
+  );
+
+  let next = new Date(from.getFullYear(), month - 1, day);
+  if (next < reference) {
+    next = new Date(from.getFullYear() + 1, month - 1, day);
+  }
+
+  const MS_PER_DAY = 24 * 60 * 60 * 1000;
+  return Math.round((next.getTime() - reference.getTime()) / MS_PER_DAY);
+}
+
+/**
+ * Human-friendly countdown to the next occurrence of the given day/month.
+ * Returns "aujourd'hui 🎉" when the birthday is today, otherwise a Discord
+ * relative timestamp (e.g. "dans 5 jours") pointing at the next occurrence.
+ */
+export function formatBirthdayCountdown(
+  month: number,
+  day: number,
+  from: Date,
+): string {
+  if (daysUntilBirthday(month, day, from) === 0) {
+    return "aujourd'hui 🎉";
+  }
+
+  return time(nextBirthdayDate(month, day, from), TimestampStyles.RelativeTime);
+}
+
+/** Whether `date` falls on the same calendar day (local time) as `reference`. */
+export function isSameLocalDay(date: Date | null, reference: Date): boolean {
+  if (!date) {
+    return false;
+  }
+
+  return (
+    date.getFullYear() === reference.getFullYear() &&
+    date.getMonth() === reference.getMonth() &&
+    date.getDate() === reference.getDate()
+  );
+}

--- a/src/modules/birthdays/birthday.utils.ts
+++ b/src/modules/birthdays/birthday.utils.ts
@@ -28,6 +28,9 @@ export function formatLongDayMonth(day: number, month: number): string {
 /**
  * Returns the next calendar date (local midnight) on which the given day/month
  * occurs, relative to `from`. When the birthday is today, returns today.
+ *
+ * A 29 February birthday is observed on 28 February in non-leap years so the
+ * countdown never silently rolls over into March.
  */
 export function nextBirthdayDate(month: number, day: number, from: Date): Date {
   const reference = new Date(
@@ -36,12 +39,26 @@ export function nextBirthdayDate(month: number, day: number, from: Date): Date {
     from.getDate(),
   );
 
-  let next = new Date(from.getFullYear(), month - 1, day);
+  let next = buildBirthdayDate(from.getFullYear(), month, day);
   if (next < reference) {
-    next = new Date(from.getFullYear() + 1, month - 1, day);
+    next = buildBirthdayDate(from.getFullYear() + 1, month, day);
   }
 
   return next;
+}
+
+/** Whether `year` is a leap year in the proleptic Gregorian calendar. */
+function isLeapYear(year: number): boolean {
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+}
+
+/**
+ * Builds a local-midnight date for a birthday in a given year, clamping
+ * 29 February to 28 February in non-leap years to avoid rolling into March.
+ */
+function buildBirthdayDate(year: number, month: number, day: number): Date {
+  const safeDay = month === 2 && day === 29 && !isLeapYear(year) ? 28 : day;
+  return new Date(year, month - 1, safeDay);
 }
 
 /**
@@ -59,10 +76,7 @@ export function daysUntilBirthday(
     from.getDate(),
   );
 
-  let next = new Date(from.getFullYear(), month - 1, day);
-  if (next < reference) {
-    next = new Date(from.getFullYear() + 1, month - 1, day);
-  }
+  const next = nextBirthdayDate(month, day, from);
 
   const MS_PER_DAY = 24 * 60 * 60 * 1000;
   return Math.round((next.getTime() - reference.getTime()) / MS_PER_DAY);

--- a/src/modules/birthdays/commands/birthday.command.ts
+++ b/src/modules/birthdays/commands/birthday.command.ts
@@ -1,0 +1,120 @@
+import { IsabelleCommand } from '@/manager/commands/command.interface.js';
+import { handleConfigBirthdayCommand } from '@/modules/birthdays/commands/config.command.js';
+import { handleListBirthdaysCommand } from '@/modules/birthdays/commands/list.command.js';
+import { handleRemoveBirthdayCommand } from '@/modules/birthdays/commands/remove.command.js';
+import { handleSetBirthdayCommand } from '@/modules/birthdays/commands/set.command.js';
+import { handleTestBirthdayCommand } from '@/modules/birthdays/commands/test.command.js';
+import { handleUpcomingBirthdaysCommand } from '@/modules/birthdays/commands/upcoming.command.js';
+import {
+  ChannelType,
+  ChatInputCommandInteraction,
+  SlashCommandBuilder,
+  SlashCommandOptionsOnlyBuilder,
+  SlashCommandSubcommandsOnlyBuilder,
+} from 'discord.js';
+
+export class BirthdayCommand implements IsabelleCommand {
+  commandData:
+    | SlashCommandBuilder
+    | SlashCommandSubcommandsOnlyBuilder
+    | SlashCommandOptionsOnlyBuilder = new SlashCommandBuilder()
+    .setName('anniversaires')
+    .setDescription('Gère les anniversaires des membres du serveur')
+    .addSubcommand((subcommand) =>
+      subcommand
+        .setName('set')
+        .setDescription("Définir une date d'anniversaire")
+        .addStringOption((option) =>
+          option
+            .setName('date')
+            .setDescription("Votre date d'anniversaire au format JJ/MM")
+            .setRequired(true),
+        )
+        .addUserOption((option) =>
+          option
+            .setName('utilisateur')
+            .setDescription(
+              "L'anniversaire de quel utilisateur voulez-vous définir ?",
+            ),
+        ),
+    )
+    .addSubcommand((subcommand) =>
+      subcommand
+        .setName('remove')
+        .setDescription("Supprimer une date d'anniversaire")
+        .addUserOption((option) =>
+          option
+            .setName('utilisateur')
+            .setDescription(
+              "L'anniversaire de quel utilisateur voulez-vous supprimer ?",
+            )
+            .setRequired(true),
+        ),
+    )
+    .addSubcommand((subcommand) =>
+      subcommand
+        .setName('list')
+        .setDescription('Afficher la liste des anniversaires du serveur'),
+    )
+    .addSubcommand((subcommand) =>
+      subcommand
+        .setName('prochains')
+        .setDescription('Afficher les prochains anniversaires du serveur'),
+    )
+    .addSubcommand((subcommand) =>
+      subcommand
+        .setName('config')
+        .setDescription(
+          "Configurer le salon d'annonce des anniversaires (admin)",
+        )
+        .addChannelOption((option) =>
+          option
+            .setName('salon')
+            .setDescription('Le salon où annoncer les anniversaires')
+            .addChannelTypes(
+              ChannelType.GuildText,
+              ChannelType.GuildAnnouncement,
+            )
+            .setRequired(true),
+        ),
+    )
+    .addSubcommand((subcommand) =>
+      subcommand
+        .setName('test')
+        .setDescription(
+          'Envoyer une annonce de test dans le salon configuré (admin)',
+        ),
+    );
+
+  async executeCommand(
+    interaction: ChatInputCommandInteraction,
+  ): Promise<void> {
+    const subcommand = interaction.options.getSubcommand();
+
+    switch (subcommand) {
+      case 'set':
+        await handleSetBirthdayCommand(interaction);
+        break;
+      case 'remove':
+        await handleRemoveBirthdayCommand(interaction);
+        break;
+      case 'list':
+        await handleListBirthdaysCommand(interaction);
+        break;
+      case 'prochains':
+        await handleUpcomingBirthdaysCommand(interaction);
+        break;
+      case 'config':
+        await handleConfigBirthdayCommand(interaction);
+        break;
+      case 'test':
+        await handleTestBirthdayCommand(interaction);
+        break;
+      default:
+        await interaction.reply({
+          content: 'Sous-commande inconnue.',
+          ephemeral: true,
+        });
+    }
+  }
+}

--- a/src/modules/birthdays/commands/config.command.ts
+++ b/src/modules/birthdays/commands/config.command.ts
@@ -1,0 +1,63 @@
+import { configManager } from '@/manager/config.manager.js';
+import { isBirthdayAdmin } from '@/modules/birthdays/birthday.permissions.js';
+import { createLogger } from '@/utils/logger.js';
+import { ChannelType, ChatInputCommandInteraction } from 'discord.js';
+
+const logger = createLogger('birthday-config-command');
+
+export async function handleConfigBirthdayCommand(
+  interaction: ChatInputCommandInteraction,
+) {
+  if (!interaction.guildId) {
+    await interaction.reply({
+      content: 'Cette commande ne peut être utilisée que sur un serveur.',
+      ephemeral: true,
+    });
+    return;
+  }
+
+  if (!isBirthdayAdmin(interaction)) {
+    await interaction.reply({
+      content:
+        "Tu n'as pas les permissions nécessaires pour configurer ce module. (Gérer le serveur)",
+      ephemeral: true,
+    });
+    return;
+  }
+
+  const channel = interaction.options.getChannel('salon', true);
+
+  if (
+    channel.type !== ChannelType.GuildText &&
+    channel.type !== ChannelType.GuildAnnouncement
+  ) {
+    await interaction.reply({
+      content: 'Le salon choisi doit être un salon textuel.',
+      ephemeral: true,
+    });
+    return;
+  }
+
+  await interaction.deferReply({ ephemeral: true });
+
+  try {
+    const currentConfig = configManager.getGuild(interaction.guildId);
+
+    await configManager.saveGuild(interaction.guildId, {
+      ...currentConfig,
+      BIRTHDAY_CHANNEL_ID: channel.id,
+    });
+
+    await interaction.editReply(
+      `Configuration mise à jour ✅\nLes anniversaires seront annoncés dans <#${channel.id}>.`,
+    );
+  } catch (error) {
+    logger.error(
+      { error, guildId: interaction.guildId, channelId: channel.id },
+      'Une erreur est survenue lors de la configuration du salon des anniversaires',
+    );
+    await interaction.editReply(
+      'Une erreur est survenue lors de la mise à jour de la configuration. Veuillez réessayer plus tard.',
+    );
+  }
+}

--- a/src/modules/birthdays/commands/config.command.ts
+++ b/src/modules/birthdays/commands/config.command.ts
@@ -1,7 +1,11 @@
 import { configManager } from '@/manager/config.manager.js';
 import { isBirthdayAdmin } from '@/modules/birthdays/birthday.permissions.js';
 import { createLogger } from '@/utils/logger.js';
-import { ChannelType, ChatInputCommandInteraction } from 'discord.js';
+import {
+  ChannelType,
+  ChatInputCommandInteraction,
+  PermissionFlagsBits,
+} from 'discord.js';
 
 const logger = createLogger('birthday-config-command');
 
@@ -39,6 +43,24 @@ export async function handleConfigBirthdayCommand(
   }
 
   await interaction.deferReply({ ephemeral: true });
+
+  // Make sure Isabelle can actually post in the chosen channel, otherwise the
+  // daily announcement would silently fail later on.
+  const me = interaction.guild?.members.me;
+  const targetChannel = interaction.guild?.channels.cache.get(channel.id);
+
+  if (me && targetChannel) {
+    const permissions = targetChannel.permissionsFor(me);
+    if (
+      !permissions.has(PermissionFlagsBits.ViewChannel) ||
+      !permissions.has(PermissionFlagsBits.SendMessages)
+    ) {
+      await interaction.editReply(
+        `Je n'ai pas la permission de voir et d'envoyer des messages dans <#${channel.id}>. Donne-moi ces accès puis relance la commande.`,
+      );
+      return;
+    }
+  }
 
   try {
     const currentConfig = configManager.getGuild(interaction.guildId);

--- a/src/modules/birthdays/commands/list.command.ts
+++ b/src/modules/birthdays/commands/list.command.ts
@@ -1,0 +1,72 @@
+import { birthdayRepository } from '@/modules/birthdays/birthday.repository.js';
+import {
+  formatBirthdayCountdown,
+  formatLongDayMonth,
+  nextBirthdayDate,
+} from '@/modules/birthdays/birthday.utils.js';
+import { createLogger } from '@/utils/logger.js';
+import { ChatInputCommandInteraction } from 'discord.js';
+
+const logger = createLogger('birthday-list-command');
+
+export async function handleListBirthdaysCommand(
+  interaction: ChatInputCommandInteraction,
+) {
+  await interaction.deferReply({ ephemeral: true });
+
+  if (!interaction.guildId || !interaction.guild) {
+    await interaction.editReply(
+      'Cette commande ne peut être utilisée que sur un serveur.',
+    );
+    return;
+  }
+
+  try {
+    const birthdays = await birthdayRepository.listBirthdays(
+      interaction.guildId,
+    );
+
+    if (birthdays.length === 0) {
+      await interaction.editReply(
+        "Aucun anniversaire n'a été défini sur ce serveur.",
+      );
+      return;
+    }
+
+    const members = await interaction.guild.members
+      .fetch({ user: birthdays.map((b) => b.userId) })
+      .catch(() => null);
+
+    const now = new Date();
+
+    const birthdayList = birthdays
+      .map((b) => ({
+        ...b,
+        next: nextBirthdayDate(b.month, b.day, now),
+      }))
+      .sort((a, b) => a.next.getTime() - b.next.getTime())
+      .map((b) => {
+        const displayName =
+          members?.get(b.userId)?.displayName ?? `<@${b.userId}>`;
+        const date = formatLongDayMonth(b.day, b.month);
+        const countdown = formatBirthdayCountdown(b.month, b.day, now);
+        return `**${displayName}** — ${date} (${countdown})`;
+      })
+      .join('\n');
+
+    await interaction.editReply(
+      `🎂 Liste des anniversaires :\n${birthdayList}`,
+    );
+  } catch (error) {
+    logger.error(
+      {
+        error,
+        guildId: interaction.guildId,
+      },
+      'Une erreur est survenue lors de la récupération des anniversaires',
+    );
+    await interaction.editReply(
+      'Une erreur est survenue lors de la récupération des anniversaires. Veuillez réessayer plus tard.',
+    );
+  }
+}

--- a/src/modules/birthdays/commands/remove.command.ts
+++ b/src/modules/birthdays/commands/remove.command.ts
@@ -30,7 +30,7 @@ export async function handleRemoveBirthdayCommand(
     await birthdayRepository.removeBirthday(interaction.guildId, user.id);
 
     await interaction.editReply(
-      `L'anniversaire de ${user.tag} a été supprimé.`,
+      `L'anniversaire de ${user.toString()} a été supprimé.`,
     );
   } catch (error) {
     logger.error(

--- a/src/modules/birthdays/commands/remove.command.ts
+++ b/src/modules/birthdays/commands/remove.command.ts
@@ -1,0 +1,48 @@
+import { isBirthdayAdmin } from '@/modules/birthdays/birthday.permissions.js';
+import { birthdayRepository } from '@/modules/birthdays/birthday.repository.js';
+import { createLogger } from '@/utils/logger.js';
+import { ChatInputCommandInteraction } from 'discord.js';
+
+const logger = createLogger('birthday-remove-command');
+
+export async function handleRemoveBirthdayCommand(
+  interaction: ChatInputCommandInteraction,
+) {
+  await interaction.deferReply({ ephemeral: true });
+
+  if (!interaction.guildId) {
+    await interaction.editReply(
+      'Cette commande ne peut être utilisée que sur un serveur.',
+    );
+    return;
+  }
+
+  if (!isBirthdayAdmin(interaction)) {
+    await interaction.editReply(
+      'Seuls les administrateurs du serveur peuvent supprimer un anniversaire. Tu peux modifier le tien avec `/anniversaires set`.',
+    );
+    return;
+  }
+
+  const user = interaction.options.getUser('utilisateur', true);
+
+  try {
+    await birthdayRepository.removeBirthday(interaction.guildId, user.id);
+
+    await interaction.editReply(
+      `L'anniversaire de ${user.tag} a été supprimé.`,
+    );
+  } catch (error) {
+    logger.error(
+      {
+        error,
+        guildId: interaction.guildId,
+        userId: user.id,
+      },
+      "Une erreur est survenue lors de la suppression de l'anniversaire",
+    );
+    await interaction.editReply(
+      "Une erreur est survenue lors de la suppression de l'anniversaire. Veuillez réessayer plus tard.",
+    );
+  }
+}

--- a/src/modules/birthdays/commands/set.command.ts
+++ b/src/modules/birthdays/commands/set.command.ts
@@ -1,0 +1,82 @@
+import { isBirthdayAdmin } from '@/modules/birthdays/birthday.permissions.js';
+import { birthdayRepository } from '@/modules/birthdays/birthday.repository.js';
+import {
+  formatDayMonth,
+  formatLongDayMonth,
+  isValidMonthDay,
+} from '@/modules/birthdays/birthday.utils.js';
+import { createLogger } from '@/utils/logger.js';
+import { ChatInputCommandInteraction } from 'discord.js';
+
+const logger = createLogger('birthday-set-command');
+
+export async function handleSetBirthdayCommand(
+  interaction: ChatInputCommandInteraction,
+) {
+  await interaction.deferReply({ ephemeral: true });
+
+  if (!interaction.guildId) {
+    await interaction.editReply(
+      'Cette commande ne peut être utilisée que sur un serveur.',
+    );
+    return;
+  }
+
+  const user = interaction.options.getUser('utilisateur') ?? interaction.user;
+
+  if (user.id !== interaction.user.id && !isBirthdayAdmin(interaction)) {
+    await interaction.editReply(
+      'Tu ne peux définir que ton propre anniversaire. Seuls les administrateurs du serveur peuvent définir celui des autres.',
+    );
+    return;
+  }
+
+  const date = interaction.options.getString('date', true);
+  const dateRegex = /^(\d{2})\/(\d{2})$/;
+
+  const match = dateRegex.exec(date);
+  if (!match) {
+    await interaction.editReply(
+      'Le format de la date est invalide. Veuillez utiliser le format JJ/MM.',
+    );
+    return;
+  }
+
+  const [, dayStr, monthStr] = match;
+  const day = parseInt(dayStr, 10);
+  const month = parseInt(monthStr, 10);
+
+  if (!isValidMonthDay(month, day)) {
+    await interaction.editReply(
+      'La date est invalide. Vérifiez que le jour et le mois existent (format JJ/MM).',
+    );
+    return;
+  }
+
+  try {
+    await birthdayRepository.setBirthday(
+      interaction.guildId,
+      user.id,
+      month,
+      day,
+    );
+
+    await interaction.editReply(
+      `L'anniversaire de ${user.toString()} a été défini au **${formatLongDayMonth(day, month)}** (${formatDayMonth(day, month)}).`,
+    );
+  } catch (error) {
+    logger.error(
+      {
+        error,
+        guildId: interaction.guildId,
+        userId: user.id,
+        month,
+        day,
+      },
+      "Une erreur est survenue lors de la définition de l'anniversaire",
+    );
+    await interaction.editReply(
+      "Une erreur est survenue lors de la définition de l'anniversaire. Veuillez réessayer plus tard.",
+    );
+  }
+}

--- a/src/modules/birthdays/commands/test.command.ts
+++ b/src/modules/birthdays/commands/test.command.ts
@@ -1,0 +1,52 @@
+import { sendBirthdayPreview } from '@/modules/birthdays/birthday.announcer.js';
+import { isBirthdayAdmin } from '@/modules/birthdays/birthday.permissions.js';
+import { createLogger } from '@/utils/logger.js';
+import { ChatInputCommandInteraction } from 'discord.js';
+
+const logger = createLogger('birthday-test-command');
+
+export async function handleTestBirthdayCommand(
+  interaction: ChatInputCommandInteraction,
+) {
+  await interaction.deferReply({ ephemeral: true });
+
+  if (!interaction.guildId) {
+    await interaction.editReply(
+      'Cette commande ne peut être utilisée que sur un serveur.',
+    );
+    return;
+  }
+
+  if (!isBirthdayAdmin(interaction)) {
+    await interaction.editReply(
+      "Seuls les administrateurs du serveur peuvent tester l'annonce des anniversaires.",
+    );
+    return;
+  }
+
+  try {
+    const sent = await sendBirthdayPreview(
+      interaction.guildId,
+      interaction.user.id,
+    );
+
+    if (!sent) {
+      await interaction.editReply(
+        "Aucun salon d'annonce n'est configuré (ou il n'est pas accessible). Utilise `/anniversaires config` pour en définir un.",
+      );
+      return;
+    }
+
+    await interaction.editReply(
+      "Annonce de test envoyée dans le salon configuré. C'était juste un test, aucune base de données n'a été modifiée.",
+    );
+  } catch (error) {
+    logger.error(
+      { error, guildId: interaction.guildId },
+      "Une erreur est survenue lors de l'envoi de l'annonce de test",
+    );
+    await interaction.editReply(
+      "Une erreur est survenue lors de l'envoi de l'annonce de test. Veuillez réessayer plus tard.",
+    );
+  }
+}

--- a/src/modules/birthdays/commands/upcoming.command.ts
+++ b/src/modules/birthdays/commands/upcoming.command.ts
@@ -1,0 +1,76 @@
+import { birthdayRepository } from '@/modules/birthdays/birthday.repository.js';
+import {
+  daysUntilBirthday,
+  formatBirthdayCountdown,
+  formatLongDayMonth,
+} from '@/modules/birthdays/birthday.utils.js';
+import { createLogger } from '@/utils/logger.js';
+import { ChatInputCommandInteraction } from 'discord.js';
+
+const logger = createLogger('birthday-upcoming-command');
+
+const UPCOMING_WINDOW_DAYS = 7;
+
+export async function handleUpcomingBirthdaysCommand(
+  interaction: ChatInputCommandInteraction,
+) {
+  await interaction.deferReply({ ephemeral: true });
+
+  if (!interaction.guildId || !interaction.guild) {
+    await interaction.editReply(
+      'Cette commande ne peut être utilisée que sur un serveur.',
+    );
+    return;
+  }
+
+  try {
+    const now = new Date();
+    const birthdays = await birthdayRepository.listBirthdays(
+      interaction.guildId,
+    );
+
+    const upcomingBirthdays = birthdays
+      .map((birthday) => ({
+        ...birthday,
+        daysUntil: daysUntilBirthday(birthday.month, birthday.day, now),
+      }))
+      .filter((birthday) => birthday.daysUntil <= UPCOMING_WINDOW_DAYS)
+      .sort((a, b) => a.daysUntil - b.daysUntil);
+
+    if (upcomingBirthdays.length === 0) {
+      await interaction.editReply(
+        `Aucun anniversaire à venir dans les ${UPCOMING_WINDOW_DAYS.toString()} prochains jours.`,
+      );
+      return;
+    }
+
+    const members = await interaction.guild.members
+      .fetch({ user: upcomingBirthdays.map((b) => b.userId) })
+      .catch(() => null);
+
+    const birthdayList = upcomingBirthdays
+      .map((b) => {
+        const displayName =
+          members?.get(b.userId)?.displayName ?? `<@${b.userId}>`;
+        const date = formatLongDayMonth(b.day, b.month);
+        const countdown = formatBirthdayCountdown(b.month, b.day, now);
+        return `**${displayName}** — ${date} (${countdown})`;
+      })
+      .join('\n');
+
+    await interaction.editReply(
+      `🎉 Anniversaires à venir dans les ${UPCOMING_WINDOW_DAYS.toString()} prochains jours :\n${birthdayList}`,
+    );
+  } catch (error) {
+    logger.error(
+      {
+        error,
+        guildId: interaction.guildId,
+      },
+      'Une erreur est survenue lors de la récupération des anniversaires à venir',
+    );
+    await interaction.editReply(
+      'Une erreur est survenue lors de la récupération des anniversaires à venir. Veuillez réessayer plus tard.',
+    );
+  }
+}

--- a/src/modules/reminders/reminder.repository.ts
+++ b/src/modules/reminders/reminder.repository.ts
@@ -26,7 +26,7 @@ export const getUserReminders = (
       ),
     )
     .orderBy(asc(reminders.dueAt), asc(reminders.id))
-    .limit(25) as Promise<UserReminder[]>;
+    .limit(25);
 };
 
 export const getUserReminderById = async (

--- a/src/modules/roast/command/services/roast-error-handler.ts
+++ b/src/modules/roast/command/services/roast-error-handler.ts
@@ -25,11 +25,7 @@ function extractErrorDetails(error: unknown): string | null {
     if ('data' in error.cause && error.cause.data) {
       const data = error.cause.data as Record<string, unknown>;
       if ('error' in data && data.error && typeof data.error === 'object') {
-        apiError = data.error as {
-          code?: number;
-          message?: string;
-          status?: string;
-        };
+        apiError = data.error;
       }
     }
   }
@@ -42,11 +38,7 @@ function extractErrorDetails(error: unknown): string | null {
   ) {
     const data = error.data as Record<string, unknown>;
     if ('error' in data && data.error && typeof data.error === 'object') {
-      apiError = data.error as {
-        code?: number;
-        message?: string;
-        status?: string;
-      };
+      apiError = data.error;
     }
   }
 

--- a/src/modules/sutom/commands/subcommands/sutom-guess.ts
+++ b/src/modules/sutom/commands/subcommands/sutom-guess.ts
@@ -5,7 +5,6 @@ import {
 } from '@/modules/sutom/core/guess-handler.js';
 import { createLogger } from '@/utils/logger.js';
 import {
-  AnyThreadChannel,
   AttachmentBuilder,
   ChatInputCommandInteraction,
   EmbedBuilder,
@@ -60,7 +59,7 @@ export default async function guessWordSubcommand(
     return;
   }
 
-  const gameChannel = channel as AnyThreadChannel;
+  const gameChannel = channel;
 
   // Additional validation: check if there's a game associated with this thread
   const threadGame = sutomGameManager.getGameByThreadId(gameChannel.id);

--- a/src/utils/commands.ts
+++ b/src/utils/commands.ts
@@ -24,7 +24,7 @@ export function countSubcommands(options: CommandOptions): number {
       option.type === ApplicationCommandOptionType.SubcommandGroup &&
       'options' in option
     ) {
-      count += countSubcommands(option.options as CommandOptions);
+      count += countSubcommands(option.options);
     }
   }
   return count;

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -56,7 +56,7 @@ function initializeLogging() {
       destination: currentLogPath,
       mkdir: true,
     },
-  }) as pino.DestinationStream;
+  });
 
   // Create console logger with pretty printing
   const consoleTransport: pino.DestinationStream = pino.transport({
@@ -67,7 +67,7 @@ function initializeLogging() {
       ignore: 'pid,hostname,prefix',
       messageFormat: '{if prefix}[{prefix}]{end} {msg}',
     },
-  }) as pino.DestinationStream;
+  });
 
   // Create multistream for both file and console
   // Set level on each stream to control which messages go where


### PR DESCRIPTION
## Résumé

Ajoute un module **Anniversaires** complet : enregistrement des dates, annonce quotidienne automatique et commandes de consultation.

Closes #4

## Fonctionnalités

- `/anniversaires set [date] [utilisateur]` — définir une date (JJ/MM). Les membres ne peuvent définir que la leur ; les admins peuvent définir celle des autres. La confirmation affiche la date en toutes lettres **et** au format JJ/MM.
- `/anniversaires remove [utilisateur]` — admin uniquement (on ne peut pas supprimer la sienne, seulement l'éditer via `set`).
- `/anniversaires list` — liste tous les anniversaires avec le **nom d'affichage** du serveur, la date en toutes lettres et un **compte à rebours** (timestamp relatif Discord vers la prochaine occurrence ; « aujourd'hui 🎉 » le jour J).
- `/anniversaires prochains` — anniversaires des 7 prochains jours, même formatage.
- `/anniversaires config [salon]` — admin, configure le salon d'annonce.
- `/anniversaires test` — admin, envoie une annonce de test dans le salon configuré (sans toucher la base) pour vérifier le rendu.

## Annonce quotidienne

- Envoyée à **07:45** (heure locale) via Components V2.
- **Idempotente** (`lastNotified`) : pas de doublon si le bot redémarre.
- **Rattrapage au démarrage** : annonce les anniversaires *du jour* même si le bot était hors ligne à 07:45, mais **ne rattrape jamais** les anniversaires des jours passés.

## Détails techniques

- Nouvelle table `birthdays` (migration `0015`) avec index unique `(guildId, userId)` et index sur `(month, day)`.
- `BIRTHDAY_CHANNEL_ID` ajouté à la config par serveur.
- Planification par timer (même approche que le module Reminders), pas de dépendance cron.

## Commits

1. `chore(deps)` — ajout de `@discordjs/builders` + sync du lockfile (discord.js 14.26.4)
2. `refactor` — suppression de casts de types devenus inutiles grâce aux types discord.js
3. `feat(birthdays)` — le module complet

## Tests

`npm run check` (prettier + eslint + tsc) passe. Vérifié en local avec `bun dev`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added birthday management commands: set, remove, list, and view upcoming birthdays
  * Enabled automatic daily birthday announcements to a configured guild channel
  * Added birthday channel configuration command for server administrators
  * Included test preview feature for birthday announcements

* **Chores**
  * Added new dependency for enhanced command building
  * Improved type safety across the codebase

<!-- end of auto-generated comment: release notes by coderabbit.ai -->