### PR TITLE
fix(birthdays): prevent self-removal and announce 29 Feb birthdays in non-leap years

### DIFF
--- a/src/modules/birthdays/birthday.announcer.ts
+++ b/src/modules/birthdays/birthday.announcer.ts
@@ -1,7 +1,10 @@
 import { client } from '@/index.js';
 import { configManager } from '@/manager/config.manager.js';
 import { birthdayRepository } from '@/modules/birthdays/birthday.repository.js';
-import { isSameLocalDay } from '@/modules/birthdays/birthday.utils.js';
+import {
+  isLeapYear,
+  isSameLocalDay,
+} from '@/modules/birthdays/birthday.utils.js';
 import { createLogger } from '@/utils/logger.js';
 import { ContainerBuilder, TextDisplayBuilder } from '@discordjs/builders';
 import { MessageFlags } from 'discord.js';
@@ -85,6 +88,27 @@ export function sendBirthdayPreview(
 }
 
 /**
+ * Fetches the birthdays to announce on `now`'s calendar day.
+ *
+ * On 28 February of a non-leap year it also includes 29 February birthdays, so
+ * leap-day people are still celebrated every year — consistent with the
+ * countdown, which observes 29/02 on 28/02 in non-leap years.
+ */
+async function getBirthdaysToAnnounce(now: Date) {
+  const month = now.getMonth() + 1;
+  const day = now.getDate();
+
+  const birthdays = await birthdayRepository.getBirthdaysForDay(month, day);
+
+  if (month === 2 && day === 28 && !isLeapYear(now.getFullYear())) {
+    const leapDayBirthdays = await birthdayRepository.getBirthdaysForDay(2, 29);
+    birthdays.push(...leapDayBirthdays);
+  }
+
+  return birthdays;
+}
+
+/**
  * Announces today's birthdays in each guild's configured channel.
  *
  * Idempotent: a birthday is only announced once per day thanks to the
@@ -94,13 +118,7 @@ export function sendBirthdayPreview(
  * back-announced.
  */
 export async function announceBirthdays(now: Date = new Date()): Promise<void> {
-  const month = now.getMonth() + 1;
-  const day = now.getDate();
-
-  const todaysBirthdays = await birthdayRepository.getBirthdaysForDay(
-    month,
-    day,
-  );
+  const todaysBirthdays = await getBirthdaysToAnnounce(now);
 
   const pending = todaysBirthdays.filter(
     (birthday) => !isSameLocalDay(birthday.lastNotified, now),

--- a/src/modules/birthdays/birthday.announcer.ts
+++ b/src/modules/birthdays/birthday.announcer.ts
@@ -98,14 +98,16 @@ async function getBirthdaysToAnnounce(now: Date) {
   const month = now.getMonth() + 1;
   const day = now.getDate();
 
-  const birthdays = await birthdayRepository.getBirthdaysForDay(month, day);
+  const includeLeapDay =
+    month === 2 && day === 28 && !isLeapYear(now.getFullYear());
 
-  if (month === 2 && day === 28 && !isLeapYear(now.getFullYear())) {
-    const leapDayBirthdays = await birthdayRepository.getBirthdaysForDay(2, 29);
-    birthdays.push(...leapDayBirthdays);
+  const queries = [birthdayRepository.getBirthdaysForDay(month, day)];
+  if (includeLeapDay) {
+    queries.push(birthdayRepository.getBirthdaysForDay(2, 29));
   }
 
-  return birthdays;
+  const results = await Promise.all(queries);
+  return results.flat();
 }
 
 /**

--- a/src/modules/birthdays/birthday.utils.ts
+++ b/src/modules/birthdays/birthday.utils.ts
@@ -48,7 +48,7 @@ export function nextBirthdayDate(month: number, day: number, from: Date): Date {
 }
 
 /** Whether `year` is a leap year in the proleptic Gregorian calendar. */
-function isLeapYear(year: number): boolean {
+export function isLeapYear(year: number): boolean {
   return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
 }
 

--- a/src/modules/birthdays/commands/remove.command.ts
+++ b/src/modules/birthdays/commands/remove.command.ts
@@ -26,6 +26,13 @@ export async function handleRemoveBirthdayCommand(
 
   const user = interaction.options.getUser('utilisateur', true);
 
+  if (user.id === interaction.user.id) {
+    await interaction.editReply(
+      'Tu ne peux pas supprimer ton propre anniversaire. Tu peux le modifier avec `/anniversaires set`.',
+    );
+    return;
+  }
+
   try {
     await birthdayRepository.removeBirthday(interaction.guildId, user.id);
 


### PR DESCRIPTION
## Résumé

Suivi des relectures de #293 (déjà mergée). Corrige deux problèmes signalés par les relecteurs sur le module Anniversaires.

## Corrections

### 1. Impossible de supprimer son propre anniversaire
La description de #293 indiquait qu'on ne peut pas supprimer **son propre** anniversaire (seulement l'éditer via `set`), mais un admin pouvait encore se passer en `utilisateur` pour le faire. `remove` rejette désormais explicitement la suppression de sa propre entrée et renvoie vers `/anniversaires set`.

### 2. Anniversaires du 29/02 jamais annoncés en année non-bissextile
Le compte à rebours « observe » déjà les 29/02 au 28/02 en année non-bissextile (`nextBirthdayDate`), mais l'annonce quotidienne ne récupérait que `(month, day)` = `(2, 28)` ce jour-là : les 29/02 n'étaient donc jamais annoncés ces années-là.

L'annonce inclut maintenant aussi les entrées `(2, 29)` lorsqu'on est le 28/02 d'une année non-bissextile, de façon cohérente avec le compte à rebours. `isLeapYear` est exporté depuis `birthday.utils.ts` pour éviter la duplication.

## Tests

`npm run check` (prettier + eslint + tsc) passe.
